### PR TITLE
Refactored MSVC extension for portability

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -62,7 +62,8 @@ void update()
         
         if(st->keys[GLFW_KEY_X] == K_PRESS) 
         {
-            glDeleteTextures(1, &(GLuint)items[selected].t);
+            GLuint texture_id = (GLuint) items[selected].t;
+            glDeleteTextures(1, &texture_id);
             items.erase(items.begin()+selected);
             selected = -1;
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -62,7 +62,7 @@ void update()
         
         if(st->keys[GLFW_KEY_X] == K_PRESS) 
         {
-            GLuint texture_id = (GLuint) items[selected].t;
+            GLuint texture_id = static_cast<GLuint>(items[selected].t);
             glDeleteTextures(1, &texture_id);
             items.erase(items.begin()+selected);
             selected = -1;


### PR DESCRIPTION
The MSVC extension that was used was [typecasts being able to return lvalues](https://learn.microsoft.com/en-us/cpp/build/reference/microsoft-extensions-to-c-and-cpp?view=msvc-170#casts)

This refactor allows the program to be built on linux and possibly other platforms which do not support MSVC extensions